### PR TITLE
disable highlighting random stuff

### DIFF
--- a/static/less/base.less
+++ b/static/less/base.less
@@ -17,6 +17,13 @@ table, caption, tbody, tfoot, thead, tr, th, td
   outline: 0;
   padding: 0;
   vertical-align: baseline;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
 }
 
 body


### PR DESCRIPTION
Stops the abilty to highlight random stuff (input fields are not effected)

A picture says a thousand words..
Stops this:
http://i42.tinypic.com/5vppns.png
