### PR TITLE
Minor change to display correct favicon on Apple touch devices

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -8,6 +8,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 
     <link rel="shortcut icon" href="/static/images/favicon.ico" type="image/x-icon">
+    <link rel="apple-touch-icon" href="/static/images/favicon.ico" type="image/x-icon">
 
     <!-- Web Fonts -->
     <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Droid+Serif:regular,bold">


### PR DESCRIPTION
When adding Maraschino to the homepage on Apple touch devices, the favicon will be displayed instead of a compressed screenshot...
