### PR TITLE
use https instead of http when accessing google font API

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -11,8 +11,8 @@
     <link rel="apple-touch-icon" href="/static/images/favicon.ico" type="image/x-icon">
 
     <!-- Web Fonts -->
-    <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Droid+Serif:regular,bold">
-    <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Droid+Sans:regular,bold">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Droid+Serif:regular,bold">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Droid+Sans:regular,bold">
 
     <!-- CSS -->
     <link rel="stylesheet/less" href="/static/less/base.less">


### PR DESCRIPTION
This resolves insecure content/mixed content warnings within the webbrowser when proxying marachino behind a SSL webserver.
