### PR TITLE
Proxy XBMC images behind maraschino so they work outside of LAN

### DIFF
--- a/modules/recently_added.py
+++ b/modules/recently_added.py
@@ -1,5 +1,6 @@
-from flask import Flask, render_template
+from flask import Flask, render_template, send_file
 import jsonrpclib
+import urllib
 
 from Maraschino import app
 from settings import *
@@ -42,13 +43,27 @@ def xhr_recently_added_albums_offset(album_offset):
     return render_recently_added_albums(album_offset)
 
 
+@app.route('/xhr/vfs_proxy/<url>')
+def xhr_vfs_proxy(url):
+    import StringIO
+    
+    try:
+        vfs_url = '%s/vfs/' % (safe_server_address())
+    except:
+        vfs_url = None
+
+    vfs_url += urllib.unquote(url)
+
+    img = StringIO.StringIO(urllib.urlopen(vfs_url).read())
+    return send_file(img, mimetype='image/jpeg')
+
 def render_recently_added_episodes(episode_offset=0):
     compact_view = get_setting_value('recently_added_compact') == '1'
 
     try:
         xbmc = jsonrpclib.Server(server_api_address())
         recently_added_episodes = get_recently_added_episodes(xbmc, episode_offset)
-        vfs_url = '%s/vfs/' % (safe_server_address())
+        vfs_url = '/xhr/vfs_proxy/'
 
     except:
         recently_added_episodes = []
@@ -68,7 +83,7 @@ def render_recently_added_movies(movie_offset=0):
     try:
         xbmc = jsonrpclib.Server(server_api_address())
         recently_added_movies = get_recently_added_movies(xbmc, movie_offset)
-        vfs_url = '%s/vfs/' % (safe_server_address())
+        vfs_url = '/xhr/vfs_proxy/'
 
     except:
         recently_added_movies = []
@@ -88,7 +103,7 @@ def render_recently_added_albums(album_offset=0):
     try:
         xbmc = jsonrpclib.Server(server_api_address())
         recently_added_albums = get_recently_added_albums(xbmc, album_offset)
-        vfs_url = '%s/vfs/' % (safe_server_address())
+        vfs_url = '/xhr/vfs_proxy/'
 
     except:
         recently_added_albums = []
@@ -133,6 +148,9 @@ def get_recently_added_episodes(xbmc, episode_offset=0):
 
         recently_added_episodes = recently_added_episodes['episodes'][episode_offset:num_recent_videos + episode_offset]
 
+        for cur_ep in recently_added_episodes:
+            cur_ep['safe_thumbnail'] = urllib.quote(cur_ep['thumbnail'], '')
+
     except:
         recently_added_episodes = []
 
@@ -147,6 +165,9 @@ def get_recently_added_movies(xbmc, movie_offset=0):
 
         recently_added_movies = recently_added_movies['movies'][movie_offset:num_recent_videos + movie_offset]
 
+        for cur_movie in recently_added_movies:
+            cur_movie['safe_thumbnail'] = urllib.quote(cur_movie['thumbnail'], '')
+
     except:
         recently_added_movies = []
 
@@ -159,6 +180,9 @@ def get_recently_added_albums(xbmc, album_offset=0):
         recently_added_albums = xbmc.AudioLibrary.GetRecentlyAddedAlbums(properties = ['title', 'year', 'rating', 'artist', 'thumbnail'])
 
         recently_added_albums = recently_added_albums['albums'][album_offset:num_recent_albums + album_offset]
+
+        for cur_album in recently_added_albums:
+            cur_album['safe_thumbnail'] = urllib.quote(cur_album['thumbnail'], '')
 
     except:
         recently_added_albums = []

--- a/templates/recently_added.html
+++ b/templates/recently_added.html
@@ -15,7 +15,7 @@
 
             {% if episode.thumbnail %}
               <div class="thumbnail">
-                <img src="{{ vfs_url }}{{ episode.thumbnail }}" alt="">
+                <img src="{{ vfs_url }}{{ episode.safe_thumbnail }}" alt="">
               </div>
             {% endif %}
 

--- a/templates/recently_added_albums.html
+++ b/templates/recently_added_albums.html
@@ -15,7 +15,7 @@
 
             {% if album.thumbnail %}
               <div class="thumbnail">
-                <img src="{{ vfs_url }}{{ album.thumbnail }}" alt="">
+                <img src="{{ vfs_url }}{{ album.safe_thumbnail }}" alt="">
               </div>
             {% endif %}
 

--- a/templates/recently_added_movies.html
+++ b/templates/recently_added_movies.html
@@ -15,7 +15,7 @@
 
             {% if movie.thumbnail %}
               <div class="thumbnail">
-                <img src="{{ vfs_url }}{{ movie.thumbnail }}" alt="">
+                <img src="{{ vfs_url }}{{ movie.safe_thumbnail }}" alt="">
               </div>
             {% endif %}
 


### PR DESCRIPTION
As it sounds. Now images aren't direct links to the XBMC machine but are links to maraschino which retrieves the request from XBMC and serves it (same way the sickbeard images work).
