### PR TITLE
Support python 2.5

### DIFF
--- a/Maraschino.py
+++ b/Maraschino.py
@@ -25,7 +25,11 @@ sys.path.insert(0, os.path.join(path_base, 'lib'))
 
 from flask import Flask, jsonify, render_template, request
 from maraschino.database import db_session
-import hashlib, json, jsonrpclib, random, urllib, os, sys
+try:
+    import json
+except ImportError:
+    import simplejson as json
+import hashlib, jsonrpclib, random, urllib, os, sys
 
 app = Flask(__name__)
 
@@ -103,7 +107,7 @@ def shutdown_session(exception=None):
 try:
     open(DATABASE)
 
-except IOError as e:
+except IOError, e:
     try:
         # check if path exists
         dbpath = os.path.dirname(DATABASE)

--- a/maraschino/modules.py
+++ b/maraschino/modules.py
@@ -1,6 +1,11 @@
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
 from flask import Flask, jsonify, render_template, request
 from maraschino.database import db_session
-import copy, json
+import copy
 
 from Maraschino import app
 from settings import *

--- a/modules/recommendations.py
+++ b/modules/recommendations.py
@@ -1,5 +1,10 @@
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
 from flask import Flask, jsonify, render_template, request
-import hashlib, json, jsonrpclib, urllib, random
+import hashlib, jsonrpclib, urllib, random
 from pprint import pprint
 
 from Maraschino import app

--- a/modules/sabnzbd.py
+++ b/modules/sabnzbd.py
@@ -1,5 +1,10 @@
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
 from flask import Flask, jsonify, render_template
-import json, jsonrpclib, urllib
+import jsonrpclib, urllib
 
 from Maraschino import app
 from settings import *

--- a/modules/sickbeard.py
+++ b/modules/sickbeard.py
@@ -1,5 +1,9 @@
+try:
+    import json
+except ImportError:
+    import simplejson as json
 from flask import Flask, jsonify, render_template, request, send_file
-import json, jsonrpclib, urllib
+import jsonrpclib, urllib
 
 from Maraschino import app
 from settings import *

--- a/modules/trakt.py
+++ b/modules/trakt.py
@@ -1,5 +1,9 @@
+try:
+    import json
+except ImportError:
+    import simplejson as json
 from flask import Flask, jsonify, render_template, request
-import hashlib, json, jsonrpclib, urllib
+import hashlib, jsonrpclib, urllib
 
 from Maraschino import app
 from settings import *


### PR DESCRIPTION
Older LTS versions of ubuntu (and other OSes probably) rely fairly heavily on python 2.5. It's not much work to supported it so I did. Only two changes required:

1) Use 2.5-style except statements (except Exception, e rather than except Exception as e)

2) Fall back to the backport version of json (simplejson) if the json import fails
