### PR TITLE
Correctly format the remaining bytes in the sab queue

### DIFF
--- a/modules/sabnzbd.py
+++ b/modules/sabnzbd.py
@@ -37,15 +37,19 @@ def xhr_sabnzbd():
         if sabnzbd['slots']:
             percentage_total = int(100 - (float(sabnzbd['mbleft']) / float(sabnzbd['mb']) * 100))
 
+        download_left = format_number(int(float(sabnzbd['mbleft'])*1024*1024))
+
     except:
         sabnzbd = None
         percentage_total = None
         download_speed = None
+        download_left = None
 
     return render_template('sabnzbd-queue.html',
         sabnzbd = sabnzbd,
         percentage_total = percentage_total,
         download_speed = download_speed,
+        download_left = download_left,
         old_config = old_config,
     )
 

--- a/templates/sabnzbd-queue.html
+++ b/templates/sabnzbd-queue.html
@@ -10,7 +10,7 @@
     </div>
 
     <div class="clearfix">
-      <p class="remaining"><strong>Remaining:</strong> {{ sabnzbd.timeleft }} / {{ sabnzbd.mbleft|int }} MB</p>
+      <p class="remaining"><strong>Remaining:</strong> {{ sabnzbd.timeleft }} / {{ download_left }}</p>
       <p class="percentage_complete">{{ percentage_total }}% complete</p>
     </div>
 {% endblock %}


### PR DESCRIPTION
Missed this one, the remaining bytes in the sab queue will be shown with the correct suffix and precision now.
