### PR TITLE
changed episode naming

### DIFF
--- a/templates/library.html
+++ b/templates/library.html
@@ -72,7 +72,7 @@
       {% if library.episodes %}
         {% for item in library.episodes %}
           <li class="{% if show_info %}info{% else %}play{% endif %}_episode" media-type="episode" data-episodeid="{{ item.episodeid }}" data-command="shows/{{ item.tvshowid }}/{{ item.season }}/{{ item.episodeid }}">
-            {{ item.season }}x{{ item.episode }} - {{ item.label }}
+            {{ item.label }}
             <span class="span">
               {% if item.resume.position >= 1 %}
                 <a class="li_buttons" id="resume_button" media-type="episode" data-id="{{ item.episodeid }}">Resume</a>


### PR DESCRIPTION
Late in edens development, it seems XBMC team decided to have the season/episode included in the label for the episode. 
Before this change the episode was returned as 2x1 - 2x01. Episode Name.
this pr changes the episode name to be 2x01. Episode Name, using only {{ item.label }}

The alternative would be to have {{ item.season }}x{{ item.episode }} - {{ item.title }}
