### PR TITLE
Make power buttons optional in Library module.

### DIFF
--- a/maraschino/modules.py
+++ b/maraschino/modules.py
@@ -70,6 +70,12 @@ AVAILABLE_MODULES = [
                 'description': 'Show Watched TV/Episodes',
                 'type': 'bool',
             },
+			{
+				'key': 'library_show_power_buttons',
+				'value': '1',
+				'description': 'Show Power Controls',
+				'type': 'bool',
+			},
         ]
     },
     {

--- a/modules/library.py
+++ b/modules/library.py
@@ -421,6 +421,7 @@ def xhr_library_files_directory(file_type):
 
 def render_library(library=None, title="Media Library", file_type=None, previous_dir=None, message=None):
     show_info = get_setting_value('library_show_info') == '1'
+    show_power_buttons = get_setting_value('library_show_power_buttons') == '1'
 
     return render_template('library.html',
         library = library,
@@ -429,4 +430,5 @@ def render_library(library=None, title="Media Library", file_type=None, previous
         file_type = file_type,
         previous_dir = previous_dir,
         show_info = show_info,
+		show_power_buttons = show_power_buttons
     )

--- a/templates/library.html
+++ b/templates/library.html
@@ -333,10 +333,11 @@
   {% if message %}
       <a class="power" title="Try Wake On LAN" id="poweron"><img src="/static/images/poweron.png" width="14" height="14"/></a>
   {% endif %}
-
+  {% if show_power_buttons %}
       <a class="power" title ="Suspend" id="suspend" ><img src="/static/images/suspend.png" width="14" height="14"/></a>
       <a class="power" title ="Reboot" id="reboot" ><img src="/static/images/reboot.png" width="14" height="14"/></a>
       <a class="power" title ="Shutdown" id="poweroff" ><img src="/static/images/shutdown.png" width="14" height="14"/></a>
+  {% endif %}
 
     </div>
 </div>


### PR DESCRIPTION
This commit adds a configuration option to the Library module. That option is to show the power buttons in the Library module. By default, this option is set to "Yes" - no behavior is changed. When "No" is selected, the power buttons are not drawn at the bottom of the Library module.

I added this functionality because I mistakenly hit the power button within about five minutes of trying Maraschino for the first time. I didn't want to let it happen a second time.
