### PR TITLE
thread trakt image caching

### DIFF
--- a/modules/traktplus.py
+++ b/modules/traktplus.py
@@ -42,6 +42,7 @@ def download_image(image, file_path):
     except:
         logger.log('TRAKT :: Failed to create file %s' % file_path, 'ERROR')
         logger.log('TRAKT :: Using remote image', 'INFO')
+        threads.pop()
         return image
 
     try:


### PR DESCRIPTION
Before this the trakt module would download 1 image at a time and once that image had finished it would move on to the next. 
This PR puts each download into its own thread making downloading of images much faster (potentially 20x faster for trending)

The module will only load once all images have finished downloading.

I have tested all that i can on my setup, i have not tested where write privileges are a problem (openelec?)
