### PR TITLE
prompt user to update if no version.txt is found

### DIFF
--- a/maraschino/__init__.py
+++ b/maraschino/__init__.py
@@ -112,6 +112,8 @@ def initialize():
             f = open(version_file, 'r')
             CURRENT_COMMIT = f.read()
             f.close()
+        else:
+            COMMITS_BEHIND = -1
 
         threading.Thread(target=checkGithub).start()
 


### PR DESCRIPTION
turns out i broke this when testing git update.
anybody not using git will have to do a manual update again :(
