### PR TITLE
Fix running from outside

### DIFF
--- a/Maraschino.py
+++ b/Maraschino.py
@@ -1,6 +1,6 @@
 import sys, os
 
-rundir = os.getcwd()
+rundir = os.path.dirname(os.path.abspath(__file__))
 
 try:
     frozen = sys.frozen


### PR DESCRIPTION
Maraschino currently cannot be run from an outside directory like that:

```
python /something/to/maraschino/Maraschino.py
```

`os.getcwd()` returns the working directory from which the command has been called, not the directory of maraschino resulting in the wrong directory being added to `sys.path` and errors about missing libs.
