### PR TITLE
clean up xbmc image handling + fixes

### DIFF
--- a/mobile.py
+++ b/mobile.py
@@ -20,9 +20,6 @@ def recently_added_episodes():
         xbmc = jsonrpclib.Server(server_api_address())
         recently_added_episodes = xbmc.VideoLibrary.GetRecentlyAddedEpisodes(properties = ['title', 'season', 'episode', 'showtitle', 'playcount', 'thumbnail', 'firstaired'])['episodes']
 
-        for episode in recently_added_episodes:
-            episode['thumbnail'] = maraschino.WEBROOT + '/xhr/vfs_proxy/' + strip_special(episode['thumbnail'])
-
     except:
         logger.log('Could not retrieve recently added episodes' , 'WARNING')
 

--- a/modules/currently_playing.py
+++ b/modules/currently_playing.py
@@ -25,23 +25,11 @@ def xhr_currently_playing():
         if active_player[0]['type'] == 'audio':
             currently_playing = xbmc.Player.GetItem(playerid = 0, properties = ['title', 'duration', 'fanart', 'artist', 'albumartist', 'album', 'track', 'artistid', 'albumid', 'thumbnail', 'year'])['item']
 
-        fanart_url = currently_playing['fanart']
-        itemart_url = currently_playing['thumbnail']
-        vfs_url = maraschino.WEBROOT + '/xhr/vfs_proxy/'
-        try:
-            itemart = vfs_url + strip_special(itemart_url)
-
-        except:
-            itemart = None
+        fanart = currently_playing['fanart']
+        itemart = currently_playing['thumbnail']
 
     except:
         return jsonify({ 'playing': False })
-
-    try:
-        fanart = vfs_url + strip_special(fanart_url)
-
-    except:
-        fanart = None
 	
     return render_template('currently_playing.html',
         currently_playing = currently_playing,

--- a/modules/library.py
+++ b/modules/library.py
@@ -6,7 +6,6 @@ from maraschino.noneditable import *
 from maraschino.tools import *
 from maraschino import logger
 
-vfs_url = maraschino.WEBROOT + '/xhr/vfs_proxy/'
 xbmc_error = 'There was a problem connecting to the XBMC server'
 
 @app.route('/xhr/library')
@@ -200,13 +199,7 @@ def xhr_library_info_movie(movieid):
 
     movie = library['moviedetails']
     title = movie['title']
-    itemart_url = strip_special(movie['thumbnail'])
-
-    try:
-        itemart = vfs_url + itemart_url
-    except:
-        logger.log('LIBRARY :: No thumbnail found for %s' % movie['title'], 'INFO')
-        itemart = None
+    itemart = movie['thumbnail']
 
     return render_template('library.html',
         library = library,
@@ -229,13 +222,7 @@ def xhr_library_info_show(tvshowid):
 
     show = library['tvshowdetails']
     title = show['title']
-    itemart_url = strip_special(show['thumbnail'])
-
-    try:
-        itemart = vfs_url + itemart_url
-    except:
-        logger.log('LIBRARY :: No thumbnail found for %s' % show['title'], 'INFO')
-        itemart = None
+    itemart = show['thumbnail']
 
     bannerart = get_setting_value('library_use_bannerart') == '1'
 
@@ -261,13 +248,7 @@ def xhr_library_info_episode(episodeid):
 
     episode = library['episodedetails']
     title = episode['title']
-    itemart_url = strip_special(episode['thumbnail'])
-
-    try:
-        itemart = vfs_url + itemart_url
-    except:
-        logger.log('LIBRARY :: No thumbnail found for %s' % episode['title'], 'INFO')
-        itemart = None
+    itemart = episode['thumbnail']
 
     return render_template('library.html',
         library = library,
@@ -290,13 +271,7 @@ def xhr_library_info_artist(artistid):
 
     artist = library['artistdetails']
     title = artist['label']
-    itemart_url = strip_special(artist['thumbnail'])
-
-    try:
-        itemart = vfs_url + itemart_url
-    except:
-        logger.log('LIBRARY :: No thumbnail found for %s' % artist['title'], 'INFO')
-        itemart = None
+    itemart = artist['thumbnail']
 
     return render_template('library.html',
         library = library,
@@ -319,13 +294,7 @@ def xhr_library_info_album(albumid):
 
     album = library['albumdetails']
     title = '%s - %s' % (album['artist'], album['title'])
-    itemart_url = strip_special(album['thumbnail'])
-
-    try:
-        itemart = vfs_url + itemart_url
-    except:
-        logger.log('LIBRARY :: No thumbnail found for %s' % album['title'], 'INFO')
-        itemart = None
+    itemart = album['thumbnail']
 
     return render_template('library.html',
         library = library,

--- a/modules/recently_added.py
+++ b/modules/recently_added.py
@@ -1,11 +1,9 @@
-from flask import Flask, render_template, send_file
+from flask import Flask, render_template
 import jsonrpclib
-import urllib
 
 from maraschino import app
 from maraschino.noneditable import *
 from maraschino.tools import *
-import maraschino
 
 @app.route('/xhr/recently_added')
 @requires_auth
@@ -42,26 +40,6 @@ def xhr_recently_added_movies_offset(movie_offset):
 def xhr_recently_added_albums_offset(album_offset):
     return render_recently_added_albums(album_offset)
 
-
-@app.route('/xhr/vfs_proxy/<path:url>')
-def xhr_vfs_proxy(url):
-    import StringIO
-
-    if url.startswith('image://'):
-        url = urllib.quote(url.encode('utf-8'), '')
-        vfs_url = server_address() + '/image/' + url
-
-    else:
-        try:
-            vfs_url = '%s/vfs/' % (server_address())
-        except:
-            vfs_url = None
-
-        vfs_url += 'special://' + url
-
-    img = StringIO.StringIO(urllib.urlopen(vfs_url).read())
-    return send_file(img, mimetype='image/jpeg')
-
 def render_recently_added_episodes(episode_offset=0):
     compact_view = get_setting_value('recently_added_compact') == '1'
     show_watched = get_setting_value('recently_added_watched_episodes') == '1'
@@ -70,15 +48,12 @@ def render_recently_added_episodes(episode_offset=0):
     try:
         xbmc = jsonrpclib.Server(server_api_address())
         recently_added_episodes = get_recently_added_episodes(xbmc, episode_offset)
-        vfs_url = maraschino.WEBROOT + '/xhr/vfs_proxy/'
 
     except:
         recently_added_episodes = []
-        vfs_url = None
 
     return render_template('recently_added.html',
         recently_added_episodes = recently_added_episodes,
-        vfs_url = vfs_url,
         episode_offset = episode_offset,
         compact_view = compact_view,
         total_episodes = total_episodes,
@@ -94,15 +69,12 @@ def render_recently_added_movies(movie_offset=0):
     try:
         xbmc = jsonrpclib.Server(server_api_address())
         recently_added_movies = get_recently_added_movies(xbmc, movie_offset)
-        vfs_url = maraschino.WEBROOT + '/xhr/vfs_proxy/'
 
     except:
         recently_added_movies = []
-        vfs_url = None
 
     return render_template('recently_added_movies.html',
         recently_added_movies = recently_added_movies,
-        vfs_url = vfs_url,
         movie_offset = movie_offset,
         compact_view = compact_view,
         total_movies = total_movies,
@@ -117,15 +89,12 @@ def render_recently_added_albums(album_offset=0):
     try:
         xbmc = jsonrpclib.Server(server_api_address())
         recently_added_albums = get_recently_added_albums(xbmc, album_offset)
-        vfs_url = maraschino.WEBROOT + '/xhr/vfs_proxy/'
 
     except:
         recently_added_albums = []
-        vfs_url = None
 
     return render_template('recently_added_albums.html',
         recently_added_albums = recently_added_albums,
-        vfs_url = vfs_url,
         album_offset = album_offset,
         compact_view = compact_view,
         view_info = view_info,
@@ -177,9 +146,6 @@ def get_recently_added_episodes(xbmc, episode_offset=0):
             total_episodes = len(recently_added_episodes)
             recently_added_episodes = recently_added_episodes[episode_offset:num_recent_videos + episode_offset]
 
-        for cur_ep in recently_added_episodes:
-            cur_ep['thumbnail'] = strip_special(cur_ep['thumbnail'])
-
     except:
         recently_added_episodes = []
 
@@ -208,9 +174,6 @@ def get_recently_added_movies(xbmc, movie_offset=0):
             total_movies = len(recently_added_movies)
             recently_added_movies = recently_added_movies[movie_offset:num_recent_videos + movie_offset]
 
-        for cur_movie in recently_added_movies:
-            cur_movie['thumbnail'] = strip_special(cur_movie['thumbnail'])
-
     except:
         recently_added_movies = []
 
@@ -223,9 +186,6 @@ def get_recently_added_albums(xbmc, album_offset=0):
         recently_added_albums = xbmc.AudioLibrary.GetRecentlyAddedAlbums(properties = ['title', 'year', 'rating', 'artist', 'thumbnail'])
 
         recently_added_albums = recently_added_albums['albums'][album_offset:num_recent_albums + album_offset]
-
-        for cur_album in recently_added_albums:
-            cur_album['thumbnail'] = strip_special(cur_album['thumbnail'])
 
     except:
         recently_added_albums = []

--- a/templates/currently_playing.html
+++ b/templates/currently_playing.html
@@ -2,7 +2,7 @@
 
   {% if currently_playing.artist %}
     {% if currently_playing.thumbnail%}
-      <img class="albumart" src="{{ itemart }}">
+      <img class="albumart" src="{{ itemart|xbmc_image }}">
       <p class="item_info_artist">
     {% else %}
       <p class="item_info">
@@ -10,7 +10,7 @@
 
   {% elif currently_playing.showtitle %}
     {% if currently_playing.thumbnail%}
-      <img class="episodeart" src="{{ itemart }}">
+      <img class="episodeart" src="{{ itemart|xbmc_image }}">
       <p class="item_info_show">
     {% else %}
       <p class="item_info">
@@ -18,7 +18,7 @@
 
   {% elif currently_playing.title == '' %}
     {% if currently_playing.thumbnail%}
-      <img class="episodeart" src="{{ itemart }}">
+      <img class="episodeart" src="{{ itemart|xbmc_image }}">
       <p class="item_info_show">
     {% else %}
       <p class="item_info">
@@ -26,7 +26,7 @@
 
   {% else %}
     {% if currently_playing.thumbnail%}
-      <img class="posterart" src="{{ itemart }}">
+      <img class="posterart" src="{{ itemart|xbmc_image }}">
       <p class="item_info_movie">
     {% else %}
       <p class="item_info">

--- a/templates/library.html
+++ b/templates/library.html
@@ -41,7 +41,7 @@
       {% if library.tvshowdetails %}
       <li class="details" data-command="shows/info/{{ show.tvshowid }}">
           {% if show.thumbnail %}
-            <img class="{% if bannerart %}bannerart{% else %}posterart{% endif %}" src="{{ itemart }}">
+            <img class="{% if bannerart %}bannerart{% else %}posterart{% endif %}" src="{{ itemart|xbmc_image }}">
           {% endif %}
           <p class="p_info">
             <table border="0">
@@ -94,7 +94,7 @@
       {% if library.episodedetails %}
       <li class="details" data-command="shows/{{ episode.tvshowid }}/{{ episode.season }}/info/{{ episode.episodeid }}">
           {% if episode.thumbnail %}
-            <img class="episodeart" src="{{ itemart }}">
+            <img class="episodeart" src="{{ itemart|xbmc_image }}">
           {% endif %}
 
           <p class="p_info">
@@ -131,7 +131,7 @@
       {% if library.moviedetails %}
       <li class="details" data-command="movies/info/{{ movie.movieid }}">
           {% if movie.thumbnail %}
-            <img class="posterart" src="{{ itemart }}">
+            <img class="posterart" src="{{ itemart|xbmc_image }}">
           {% endif %}
           <p class="p_info">
             <table border="0">
@@ -160,7 +160,7 @@
       {% if library.artistdetails %}
       <li class="details" data-command="artists/info/{{ artist.artistid }}">
           {% if artist.thumbnail %}
-            <img class="artistart" src="{{ itemart }}">
+            <img class="artistart" src="{{ itemart|xbmc_image }}">
           {% endif %}
           <p class="p_info">
             <table border="0">
@@ -186,7 +186,7 @@
       {% if library.albumdetails %}
       <li class="details" data-command="artists/{{ album.artistid }}/info/{{ album.albumid }}">
           {% if album.thumbnail %}
-            <img class="albumart" src="{{ itemart }}">
+            <img class="albumart" src="{{ itemart|xbmc_image }}">
           {% endif %}
           <p class="p_info">
             <table border="0">

--- a/templates/mobile/recent_episodes.html
+++ b/templates/mobile/recent_episodes.html
@@ -8,7 +8,7 @@
   {% for episode in recently_added_episodes %}
       <li data-icon="{{ 'check' if episode.playcount else 'false' }}">
         <a class="inner play" href="#" data-episodeid="{{ episode.episodeid }}">
-          <div class="thumb"><img src="{{ episode.thumbnail }}" alt=""></div>
+          <div class="thumb"><img src="{{ episode.thumbnail|xbmc_image }}" alt=""></div>
           <h2>{{ episode.showtitle }}</h2>
           <p>{{ episode.season }}x{{ "%02d"|format(episode.episode) }} - {{ episode.title }}</p>
         </a>

--- a/templates/recently_added.html
+++ b/templates/recently_added.html
@@ -19,7 +19,7 @@
 
             {% if episode.thumbnail %}
               <div class="thumbnail">
-                <img src="{{ vfs_url }}{{ episode.thumbnail }}" alt="">
+                <img src="{{ episode.thumbnail|xbmc_image }}" alt="">
               </div>
             {% endif %}
 

--- a/templates/recently_added_albums.html
+++ b/templates/recently_added_albums.html
@@ -19,7 +19,7 @@
 
             {% if album.thumbnail %}
               <div class="thumbnail">
-                <img src="{{ vfs_url }}{{ album.thumbnail }}" alt="">
+                <img src="{{ album.thumbnail|xbmc_image }}" alt="">
               </div>
             {% endif %}
 

--- a/templates/recently_added_movies.html
+++ b/templates/recently_added_movies.html
@@ -19,7 +19,7 @@
 
             {% if movie.thumbnail and not compact_view %}
               <div class="thumbnail">
-                <img src="{{ vfs_url }}{{ movie.thumbnail }}" alt="">
+                <img src="{{ movie.thumbnail|xbmc_image }}" alt="">
               </div>
             {% endif %}
 


### PR DESCRIPTION
IMO this is a much cleaner way of proxying the xbmc images. Before you needed to do <code>strip_special(url)</code> then change the url to <code>/xhr/vfs_proxy/url</code>

With this method all that needs to be done is to use the filter in the template: <code>{{ itemart|xbmc_image }}</code>

While doing the cleanup i fixed a bug where some music albumart was not being parsed properly (because it was a http:// address rather than a xbmc thumbnail).
Any images that do not pass the 'special://' and 'image://' checks are left alone.

There is also a fix for broken frodo images(B4 they only worked in werkzeug server).

new eden url:
http://localhost:7000/xhr/xbmc_image/eden/masterprofile/Thumbnails/Video/6/67bcfc96.tbn

new frodo url:
http://localhost:7000/xhr/xbmc_image/frodo/smb%253a%252f%252fUNRAID%252fTV%2520SHOWS%252fBones%252ffolder%252ejpg
