### PR TITLE
databaselocation set for daemon. 

### DIFF
--- a/default
+++ b/default
@@ -14,11 +14,19 @@ APP_PATH=/opt/maraschino
 ENABLE_DAEMON=1
 
 # [required] user or uid of account to run the program as:
-RUN_AS=root
+RUN_AS=
+
+# [optional] change to 0 to disable updating from git/webinterface as $RUN_AS
+# this changes ownership of /opt/maraschino to user set @ RUN_AS
+WEB_UPDATE=1
+
+# [optional] full path to the folder to store database in;
+# otherwise, the default location (~/.maraschino/maraschino.db) is used:
+DATADIR=
+
+# [optional] Force port number to listen on, otherwise 7000 is used:
+PORT=
 
 # [optional] full path for the pidfile
 # otherwise, the default location /var/run/maraschino/maraschino.pid is used:
 PID_FILE=
-
-# [required] port to listen on (defaults to 7000)
-PORT=7000


### PR DESCRIPTION
Maybe nemesis can also do logfiles into DATADIR? When programfiles are protected by root ownership and a local user runs maraschino it wil give errors because it can't create a Logdir. If logdir is inside datadir which can be set @ homefolder of the running user this problem won't persist. (also logging into a different location is good for SSD's/USB's on which a lot of writing wears out lifetime.

(I don't have time anymore to write the loggerdirectory code myself, otherwise I wouldn't have asked).
