### PR TITLE
Fix for applications module losing setting for opening new tab.

### DIFF
--- a/maraschino/modules.py
+++ b/maraschino/modules.py
@@ -27,7 +27,7 @@ AVAILABLE_MODULES = [
         'name': 'applications',
         'label': 'Applications',
         'description': 'Allows you to link to whatever applications you want (SabNZBd, SickBeard, etc.)',
-        'static': False,
+        'static': True,
         'poll': 0,
         'delay': 0,
         'settings': [

--- a/modules/index.py
+++ b/modules/index.py
@@ -46,6 +46,8 @@ def index():
 
     except:
         pass
+    
+    new_tab = get_setting_value('app_new_tab') == '1'
 
     # display random background when not watching media (if setting enabled)
     # only changes on page refresh
@@ -129,7 +131,8 @@ def index():
         library_show_power_buttons = library_show_power_buttons,
         show_tutorial = unorganised_modules.count() == 0,
         webroot = maraschino.WEBROOT,
-        kiosk = maraschino.KIOSK
+        kiosk = maraschino.KIOSK,
+        new_tab = new_tab
     )
 
 @app.route('/xhr/shutdown')


### PR DESCRIPTION
Noticed that every time Maraschino is restarted the Application module seems to forget that I set it to open in a new tab. Not sure if this is the best way to do this, but it does fix the issue.

Note, I also have not mastered git yet, as somehow, while trying to revert my last commit I accidentally closed the previous pull request (https://github.com/mrkipling/maraschino/pull/197). I meant for this all to stay in that one. Sorry for the second PR.
