### PR TITLE
Add support for non-root web paths in sickbeard, couchpotato, headphones and sabnzbd

### DIFF
--- a/maraschino/modules.py
+++ b/maraschino/modules.py
@@ -73,6 +73,11 @@ AVAILABLE_MODULES = [
                 'description': 'CouchPotato Port',
             },
             {
+                'key': 'couchpotato_webroot',
+                'value': '',
+                'description': 'CouchPotato Webroot',
+            },
+            {
                 'key': 'couchpotato_https',
                 'value': '0',
                 'description': 'Use HTTPS',
@@ -111,6 +116,11 @@ AVAILABLE_MODULES = [
                 'key': 'headphones_port',
                 'value': '',
                 'description': 'Headphones Port',
+            },
+            {
+                'key': 'headphones_webroot',
+                'value': '',
+                'description': 'Headphones Webroot',
             },
             {
                 'key': 'headphones_user',
@@ -324,6 +334,11 @@ AVAILABLE_MODULES = [
                 'description': 'Port',
             },
             {
+                'key': 'sabnzbd_webroot',
+                'value': '',
+                'description': 'Webroot',
+            },
+            {
                 'key': 'sabnzbd_api',
                 'value': '',
                 'description': 'API Key',
@@ -488,6 +503,11 @@ AVAILABLE_MODULES = [
                 'key': 'sickbeard_port',
                 'value': '',
                 'description': 'Sickbeard Port',
+            },
+            {
+                'key': 'sickbeard_webroot',
+                'value': '',
+                'description': 'Sickbeard Webroot',
             },
             {
                 'key': 'sickbeard_https',

--- a/modules/couchpotato.py
+++ b/modules/couchpotato.py
@@ -24,9 +24,13 @@ def login_string():
 def couchpotato_url():
     port = get_setting_value('couchpotato_port')
     url_base = get_setting_value('couchpotato_ip')
+    webroot = get_setting_value('couchpotato_webroot')
     
     if port:
         url_base = '%s:%s' % ( url_base, port )
+
+    if webroot:
+        url_base = '%s/%s' % ( url_base, webroot )
     
     url = '%s/api/%s' % ( url_base, get_setting_value('couchpotato_api') )
     

--- a/modules/headphones.py
+++ b/modules/headphones.py
@@ -16,9 +16,13 @@ def headphones_http():
 def headphones_url():
     port = get_setting_value('headphones_port')
     url_base = get_setting_value('headphones_host')
+    webroot = get_setting_value('headphones_webroot')
 
     if port:
         url_base = '%s:%s' % (url_base, port)
+
+    if webroot:
+        url_base = '%s/%s' % (url_base, webroot)
 
     return headphones_http() + url_base
 

--- a/modules/sabnzbd.py
+++ b/modules/sabnzbd.py
@@ -21,9 +21,13 @@ def sab_http():
 def sabnzbd_url_no_api():
     url_base = get_setting_value('sabnzbd_host')
     port = get_setting_value('sabnzbd_port')
+    webroot = get_setting_value('sabnzbd_webroot')
 
     if port:
         url_base = '%s:%s' % (url_base, port)
+
+    if webroot:
+       url_base = '%s/%s' % (url_base, webroot)
 
     return sab_http() + url_base
 

--- a/modules/sickbeard.py
+++ b/modules/sickbeard.py
@@ -26,9 +26,13 @@ def login_string():
 def sickbeard_url():
     port = get_setting_value('sickbeard_port')
     url_base = get_setting_value('sickbeard_ip')
+    webroot = get_setting_value('sickbeard_webroot')
 
     if port:
         url_base = '%s:%s' % (url_base, port)
+
+    if webroot:
+        url_base = '%s/%s' % (url_base, webroot)
 
     url = '%s/api/%s' % (url_base, get_setting_value('sickbeard_api'))
 


### PR DESCRIPTION
In my configuration, I have SickBeard, CouchPotato, Headphones and SabNZBd configured with non-root webpaths to support apache's mod_proxy.

With this configuration, maraschino wasn't able to access the API for any of the applications because /api/blahblahblah was returning a 404 error from the service.

This patch allows the end-user to point insert a path into the api requests so everything works again.
