### PR TITLE
removed check for getartistdetails on loading artist list

### DIFF
--- a/modules/library.py
+++ b/modules/library.py
@@ -72,14 +72,6 @@ def xhr_library_root(item_type):
             library = xbmc.AudioLibrary.GetArtists(sort={'method': 'label', 'ignorearticle': True})
             logger.log('LIBRARY :: Finished retrieveing music', 'DEBUG')
 
-            for artist in library['artists']:
-                artistid = artist['artistid']
-                try:
-                    xbmc.AudioLibrary.GetArtistDetails(artistid=artistid, properties=['description', 'thumbnail', 'genre'])
-                    artist['details'] = "True"
-                except:
-                    None
-
         if item_type == 'files':
             logger.log('LIBRARY :: Retrieving files', 'INFO')
             title = "Files"

--- a/templates/library.html
+++ b/templates/library.html
@@ -179,7 +179,7 @@
           <li class="get" file-type="audio" media-type="artist" data-id="{{ item.artistid }}" data-command="artists/{{ item.artistid }}">
             {{ item.label }}
             <span class="span">
-              {% if item.details %}<a class="li_buttons" id="info">Info</a>{% endif %}
+              <a class="li_buttons" id="info">Info</a>
               <a class="li_buttons" id="play">Play</a>
               <a class="li_buttons" id="queue">Queue</a>
             </span>


### PR DESCRIPTION
I noticed a post on the xbmc forum regarding how slow the load time is on the Music Library source when loading all the artists from xbmc. 

http://forum.xbmc.org/showthread.php?tid=113136&pid=1175033#pid1175033

Looking at the module I see there is a loop that tries to check if artist details exist for each artist, and then set a flag accordingly for the Info button. Adding this extra check took a lot of extra time to load the artists so I removed it. 

The downside is that now the Info button exists for each artist and will throw an error if you attempt to look up details for an artist and the artist doesn't have any. Since the error is caught though, I think this isn't too bad of a trade off seeing as how we are reducing the number of JSON calls by alot when loading the artist list. Most people probably have 50-100 artists at minimum, so this will take out an extra 50-100 (probably lots more) calls when loading this list. This is also the only info button that the extra check is done for, the rest are displayed and I'm assuming handle errors as they happen. 

If you think this is worth pulling into the main branch it will definitely speed up load times. 
