### PR TITLE
Add option to cache sickbeard images

### DIFF
--- a/maraschino/modules.py
+++ b/maraschino/modules.py
@@ -617,7 +617,13 @@ AVAILABLE_MODULES = [
                 'value': '0',
                 'description': 'Show air date',
                 'type': 'bool',
-            },         
+            },
+            {
+                'key': 'sickbeard_cache_img',
+                'value': '0',
+                'description': 'Cache images',
+                'type': 'bool',
+            },
         ]
     },
     {


### PR DESCRIPTION
This gives the user the option to cut down on requests to the sickbeard api. Every show makes a request for an image.
While this seems like a no brainer (at least to me). It can take a while to initially download all the images if you have a large library. That is why i have made it optional.

The naming convention I chose coincides with sickbeards, so its possible just to copy sickbeards cache over.

FYI it took about 3-4 minutes to cache 235 images on my test.
Tested on windows only.

EDIT:
If you feel this would be useful i will look into doing the same for couchpotato and headphones
