### PR TITLE
fix GIT error handling

### DIFF
--- a/maraschino/updater.py
+++ b/maraschino/updater.py
@@ -231,7 +231,7 @@ def gitUpdate():
             logger.log('UPDATER :: Already up to date', 'INFO')
             logger.log('UPDATER :: Git output: ' + str(output), 'DEBUG')
             return 'complete'
-        elif line.endswith('Aborting'):
+        elif 'Aborting' in line:
             logger.log('UPDATER :: Unable to update from git: '+line, 'ERROR')
             logger.log('UPDATER :: Output: ' + str(output), 'DEBUG')
             maraschino.USE_GIT = False


### PR DESCRIPTION
While updating when local changes were made the GIT output contains 'Aborting' without a trailing dot!
