### PR TITLE
Give the user a chance to use trakt shouts

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -159,11 +159,6 @@ $(document).ready(function() {
           $(this).replaceWith(construct_inactive_module('synopsis', 'Synopsis'));
         });
 
-        // hide trakt module if visible
-        $('#trakt').fadeOut(200, function() {
-          $(this).replaceWith(construct_inactive_module('trakt', 'trakt.tv'));
-        });
-
         currently_playing_id = null;
 
       } else {


### PR DESCRIPTION
I often find myself wanting to add a shout on trakt AFTER the movie/show has finished.

I'm not sure if this is the right way to go about it or if this is even wanted. But this stops the trakt shouts module from vanishing after the movie/show finishes. it hangs around until the page is refreshed or something else is played (like fanart).
