### PR TITLE
show correct season number in library title

### DIFF
--- a/modules/library.py
+++ b/modules/library.py
@@ -570,7 +570,7 @@ def xhr_xbmc_library_media(media_type=None):
 
             else:
                 library = xbmc_get_episodes(xbmc, int(tvshowid), int(season))
-                title = '%s - Season %s' % (library[0]['showtitle'], library[0]['season'])
+                title = '%s - Season %s' % (library[0]['showtitle'], season)
                 back_path = '/seasons?tvshowid=%s' % tvshowid
 
 


### PR DESCRIPTION
small change to fix an issue that appears when the first 'episode' in a season is a special.
If its a special "library[0]['season']" returns the season as zero.
Its just a small fix, pull it in with some other changes. I don't think it justifies an update :)
