### PR TITLE
Shows posters in their correct aspect ratio instead of cropping them

### DIFF
--- a/static/less/module-recently_added.less
+++ b/static/less/module-recently_added.less
@@ -13,6 +13,7 @@
       line-height: 1.3em;
       margin-top: 5px;
       position: relative;
+      overflow: hidden;
 
       .border-radius(4px);
 
@@ -51,34 +52,21 @@
       margin-bottom: 6px;
     }
 
-    .thumbnail {
+    div.image {
       position: absolute;
       right: 5px;
       top: 5px;
-      width: 100px;
-      height: 56px;
+      width: 14%;
+      height: 85%;
       overflow: hidden;
 
       .box-shadow(#222, 0, 0, 2px);
 
-      img {
-        width: 100px;
+      img.poster {
+        height: 100%;
+        width: 100%;
       }
-    }
 
-    .poster {
-      position: absolute;
-      right: 5px;
-      top: 5px;
-      width: 37px;
-      height: 56px;
-      overflow: hidden;
-
-      .box-shadow(#222, 0, 0, 2px);
-
-      img {
-        width: 37px;
-      }
     }
   }
 

--- a/templates/recently_added/movies.html
+++ b/templates/recently_added/movies.html
@@ -25,8 +25,8 @@
           {% endif %}
 
             {% if movie.thumbnail and not compact_view %}
-              <div class="thumbnail">
-                <img src="{{ movie.thumbnail }}" alt="">
+              <div class="image">
+                <img class="poster" src="{{ movie.thumbnail }}" alt="">
               </div>
             {% endif %}
 


### PR DESCRIPTION
The current code shows posters at the wrong aspect ratio and crops the bottom 66%. This pull request fixes that.

![image](https://f.cloud.github.com/assets/63207/1086373/b5e3c89e-15fa-11e3-8a20-3ba4dd5abb9e.png)
