### PR TITLE
Fix CloudFlare 1010 error in TraktPlus module

### DIFF
--- a/maraschino/tools.py
+++ b/maraschino/tools.py
@@ -11,6 +11,7 @@ from maraschino.models import Setting, XbmcServer
 from flask import send_file
 import StringIO
 import urllib
+import urllib2
 import re
 
 def check_auth(username, password):
@@ -247,7 +248,10 @@ def download_image(image, file_path):
 
     try:
         logger.log('Downloading %s' % image, 'INFO')
-        image_on_web = urllib.urlopen(image)
+
+        headers = { 'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.65 Safari/537.36' }
+        request = urllib2.Request(image, None, headers)
+        image_on_web = urllib2.urlopen(request, None)
         while True:
             buf = image_on_web.read(65536)
             if len(buf) == 0:


### PR DESCRIPTION
The Trakt Plus module has recently begun returning "broken" thumbnails for all shows and movies. Looking at the contents of the actual .jpg files in the cache/trakt/shows/ and cache/trakt/movies/ directories, they're full of HTML.

The HTML was generated by CloudFlare, and is an [Access Denied: Error 1010](https://support.cloudflare.com/hc/en-us/articles/200171806-Access-Denied-The-owner-of-this-website-has-banned-your-access-based-on-your-browser-s-signature) error.

This PR fixes the CloudFlare 1010 error by faking a User-Agent header when making the request for thumbnail images from Trakt.tv. I've switched to urllib2 for downloading the thumbnail images, as urllib doesn't support headers (as far as I can tell).
