### PR TITLE
Modify sickbeard module paths

### DIFF
--- a/modules/sickbeard.py
+++ b/modules/sickbeard.py
@@ -97,7 +97,7 @@ def xhr_sickbeard():
     )
 
 
-@app.route('/sickbeard/search_ep/<tvdbid>/<season>/<episode>/')
+@app.route('/xhr/sickbeard/search_ep/<tvdbid>/<season>/<episode>/')
 @requires_auth
 def search_ep(tvdbid, season, episode):
     params = '/?cmd=episode.search&tvdbid=%s&season=%s&episode=%s' % (tvdbid, season, episode)
@@ -109,7 +109,7 @@ def search_ep(tvdbid, season, episode):
         return jsonify({'result': False})
 
 
-@app.route('/sickbeard/get_plot/<tvdbid>/<season>/<episode>/')
+@app.route('/xhr/sickbeard/get_plot/<tvdbid>/<season>/<episode>/')
 def get_plot(tvdbid, season, episode):
     params = '/?cmd=episode&tvdbid=%s&season=%s&episode=%s' % (tvdbid, season, episode)
 
@@ -120,7 +120,7 @@ def get_plot(tvdbid, season, episode):
         return ''
 
 
-@app.route('/sickbeard/get_all/')
+@app.route('/xhr/sickbeard/get_all/')
 def get_all():
     params = '/?cmd=shows&sort=name'
 
@@ -140,7 +140,7 @@ def get_all():
     )
 
 
-@app.route('/sickbeard/get_show_info/<tvdbid>/')
+@app.route('/xhr/sickbeard/get_show_info/<tvdbid>/')
 def show_info(tvdbid):
     params = '/?cmd=show&tvdbid=%s' % tvdbid
 
@@ -159,7 +159,7 @@ def show_info(tvdbid):
     )
 
 
-@app.route('/sickbeard/get_season/<tvdbid>/<season>/')
+@app.route('/xhr/sickbeard/get_season/<tvdbid>/<season>/')
 def get_season(tvdbid, season):
     params = '/?cmd=show.seasons&tvdbid=%s&season=%s' % (tvdbid, season)
 
@@ -178,7 +178,7 @@ def get_season(tvdbid, season):
     )
 
 
-@app.route('/sickbeard/history/<limit>/')
+@app.route('/xhr/sickbeard/history/<limit>/')
 def history(limit):
     params = '/?cmd=history&limit=%s' % limit
     try:
@@ -199,10 +199,10 @@ def history(limit):
 
 # returns a link with the path to the required image from SB
 def get_pic(tvdb, style='banner'):
-    return '%s/sickbeard/get_%s/%s' % (maraschino.WEBROOT, style, tvdb)
+    return '%s/xhr/sickbeard/get_%s/%s' % (maraschino.WEBROOT, style, tvdb)
 
 
-@app.route('/sickbeard/get_ep_info/<tvdbid>/<season>/<ep>/')
+@app.route('/xhr/sickbeard/get_ep_info/<tvdbid>/<season>/<ep>/')
 def get_episode_info(tvdbid, season, ep):
     params = '/?cmd=episode&tvdbid=%s&season=%s&episode=%s&full_path=1' % (tvdbid, season, ep)
 
@@ -222,7 +222,7 @@ def get_episode_info(tvdbid, season, ep):
     )
 
 
-@app.route('/sickbeard/set_ep_status/<tvdbid>/<season>/<ep>/<st>/')
+@app.route('/xhr/sickbeard/set_ep_status/<tvdbid>/<season>/<ep>/<st>/')
 def set_episode_status(tvdbid, season, ep, st):
     params = '/?cmd=episode.setstatus&tvdbid=%s&season=%s&episode=%s&status=%s' % (tvdbid, season, ep, st)
 
@@ -239,7 +239,7 @@ def set_episode_status(tvdbid, season, ep, st):
     return jsonify({'status': status})
 
 
-@app.route('/sickbeard/shutdown/')
+@app.route('/xhr/sickbeard/shutdown/')
 def shutdown():
     params = '/?cmd=sb.shutdown'
 
@@ -251,7 +251,7 @@ def shutdown():
     return sickbeard['message']
 
 
-@app.route('/sickbeard/restart/')
+@app.route('/xhr/sickbeard/restart/')
 def restart():
     params = '/?cmd=sb.restart'
     try:
@@ -262,7 +262,7 @@ def restart():
     return sickbeard['message']
 
 
-@app.route('/sickbeard/search/')
+@app.route('/xhr/sickbeard/search/')
 def sb_search():
     sickbeard = {}
     params = ''
@@ -300,7 +300,7 @@ def sb_search():
     )
 
 
-@app.route('/sickbeard/add_show/<tvdbid>/')
+@app.route('/xhr/sickbeard/add_show/<tvdbid>/')
 def add_show(tvdbid):
     params = '/?cmd=show.addnew&tvdbid=%s' % tvdbid
     try:
@@ -326,21 +326,21 @@ def add_show(tvdbid):
     return sickbeard['message']
 
 
-@app.route('/sickbeard/get_banner/<tvdbid>/')
+@app.route('/xhr/sickbeard/get_banner/<tvdbid>/')
 def get_banner(tvdbid):
     params = '/?cmd=show.getbanner&tvdbid=%s' % tvdbid
     img = StringIO.StringIO(sickbeard_api(params, use_json=False))
     return send_file(img, mimetype='image/jpeg')
 
 
-@app.route('/sickbeard/get_poster/<tvdbid>/')
+@app.route('/xhr/sickbeard/get_poster/<tvdbid>/')
 def get_poster(tvdbid):
     params = '/?cmd=show.getposter&tvdbid=%s' % tvdbid
     img = StringIO.StringIO(sickbeard_api(params, use_json=False))
     return send_file(img, mimetype='image/jpeg')
 
 
-@app.route('/sickbeard/log/<level>/')
+@app.route('/xhr/sickbeard/log/<level>/')
 def log(level):
     params = '/?cmd=logs&min_level=%s' % level
     try:
@@ -359,7 +359,7 @@ def log(level):
     )
 
 
-@app.route('/sickbeard/delete_show/<tvdbid>/')
+@app.route('/xhr/sickbeard/delete_show/<tvdbid>/')
 def delete_show(tvdbid):
     params = '/?cmd=show.delete&tvdbid=%s' % tvdbid
     try:
@@ -370,7 +370,7 @@ def delete_show(tvdbid):
     return sickbeard['message']
 
 
-@app.route('/sickbeard/refresh_show/<tvdbid>/')
+@app.route('/xhr/sickbeard/refresh_show/<tvdbid>/')
 def refresh_show(tvdbid):
     params = '/?cmd=show.refresh&tvdbid=%s' % tvdbid
     try:
@@ -381,7 +381,7 @@ def refresh_show(tvdbid):
     return sickbeard['message']
 
 
-@app.route('/sickbeard/update_show/<tvdbid>/')
+@app.route('/xhr/sickbeard/update_show/<tvdbid>/')
 def update_show(tvdbid):
     params = '/?cmd=show.update&tvdbid=%s' % tvdbid
     try:

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -828,7 +828,7 @@ $(document).ready(function() {
     var ep = $(this).attr('episode');
     var season = $(this).attr('season');
     var id = $(this).attr('id');
-    $.get(WEBROOT + '/sickbeard/search_ep/'+id+'/'+season+'/'+ep)
+    $.get(WEBROOT + '/xhr/sickbeard/search_ep/'+id+'/'+season+'/'+ep)
     .success(function(data){
       if(data.result === 'success'){
         $('#sickbeard #'+id+'_'+season+'_'+ep+' div.options img.search').attr('src', WEBROOT + '/static/images/yes.png');
@@ -850,7 +850,7 @@ $(document).ready(function() {
   // Load show info from banner display
   $(document).on('click', '#sickbeard .coming_ep .options img.banner', function(){
     var tvdb = $(this).attr('id');
-    $.get(WEBROOT + '/sickbeard/get_show_info/'+tvdb, function(data){
+    $.get(WEBROOT + '/xhr/sickbeard/get_show_info/'+tvdb, function(data){
       $('#sickbeard').replaceWith(data);
     });
   });
@@ -876,7 +876,7 @@ $(document).ready(function() {
 
   // All Shows menu
   $(document).on('click', '#sickbeard .menu .all', function(){
-    $.get(WEBROOT + '/sickbeard/get_all', function(data){
+    $.get(WEBROOT + '/xhr/sickbeard/get_all', function(data){
       $('#sickbeard').replaceWith(data);
     });
   });
@@ -890,7 +890,7 @@ $(document).ready(function() {
 
   // History menu
   $(document).on('click', '#sickbeard .menu .history', function(){
-    $.get(WEBROOT + '/sickbeard/history/30', function(data){
+    $.get(WEBROOT + '/xhr/sickbeard/history/30', function(data){
       $('#sickbeard').html($(data).html());
       $('#sickbeard .menu').prepend('<li class="snatched" title="View snatched"><span>Snatched</span></li>');
     });
@@ -910,21 +910,21 @@ $(document).ready(function() {
   // Show info
   $(document).on('click', '#sickbeard #sickbeard-list ul', function(){
     var id = $(this).attr('id');
-    $.get(WEBROOT + '/sickbeard/get_show_info/'+id, function(data){
+    $.get(WEBROOT + '/xhr/sickbeard/get_show_info/'+id, function(data){
       $('#sickbeard').replaceWith(data);
     });
   });
 
   // Episode list back button functionality
   $(document).on('click', '#sb_content > #show .sb-back', function(){
-    $.get(WEBROOT + '/sickbeard/get_all', function(data){
+    $.get(WEBROOT + '/xhr/sickbeard/get_all', function(data){
       $('#sickbeard').replaceWith(data);
     });
   });
 
   // Season info
   $(document).on('click', '#sb_content > #show ul.seasons li', function(){
-    $.get(WEBROOT + '/sickbeard/get_season/'+$(this).attr('tvdbid')+'/'+$(this).attr('season'), function(data){
+    $.get(WEBROOT + '/xhr/sickbeard/get_season/'+$(this).attr('tvdbid')+'/'+$(this).attr('season'), function(data){
       $('#sickbeard').replaceWith(data);
       $('#sickbeard .episode-list .tablesorter').tablesorter({sortList: [[0,0]]});
     });
@@ -932,14 +932,14 @@ $(document).ready(function() {
 
   // Going into episode info
   $(document).on('click', '#sickbeard .episode-list #season tbody tr', function(){
-    $.get(WEBROOT + '/sickbeard/get_ep_info/'+$(this).attr('link'), function(data){
+    $.get(WEBROOT + '/xhr/sickbeard/get_ep_info/'+$(this).attr('link'), function(data){
       $('#sickbeard').replaceWith(data);
     });
   });
 
   // Episode info back button functionality
   $(document).on('click', '#sickbeard .episode-info div.back', function(){
-    $.get(WEBROOT + '/sickbeard/get_season/'+$(this).attr('tvdbid')+'/'+$(this).attr('season'), function(data){
+    $.get(WEBROOT + '/xhr/sickbeard/get_season/'+$(this).attr('tvdbid')+'/'+$(this).attr('season'), function(data){
       $('#sickbeard').replaceWith(data);
       $('#sickbeard .episode-list .tablesorter').tablesorter({sortList: [[0,0]]});
     });
@@ -947,7 +947,7 @@ $(document).ready(function() {
 
   // Back Button Episode List
   $(document).on('click', '#sickbeard .episode-list >.back', function(){
-    $.get(WEBROOT + '/sickbeard/get_show_info/'+$(this).attr('tvdbid'), function(data){
+    $.get(WEBROOT + '/xhr/sickbeard/get_show_info/'+$(this).attr('tvdbid'), function(data){
       $('#sickbeard').replaceWith(data);
     });
   });
@@ -965,7 +965,7 @@ $(document).ready(function() {
   // Delete show function
   $(document).on('click', '#sickbeard #show .manage .delete' , function(){
     var id = $('#sickbeard #show .manage').attr('tvdbid');
-    $.get(WEBROOT + '/sickbeard/delete_show/'+id)
+    $.get(WEBROOT + '/xhr/sickbeard/delete_show/'+id)
     .success(function(data){
       popup_message(data);
     })
@@ -977,7 +977,7 @@ $(document).ready(function() {
   // Refresh show function
   $(document).on('click', '#sickbeard #show .manage .refresh' , function(){
     var id = $('#sickbeard #show .manage').attr('tvdbid');
-    $.get(WEBROOT + '/sickbeard/refresh_show/'+id)
+    $.get(WEBROOT + '/xhr/sickbeard/refresh_show/'+id)
     .success(function(data){
       popup_message(data);
     })
@@ -989,7 +989,7 @@ $(document).ready(function() {
   // Update show function
   $(document).on('click', '#sickbeard #show .manage .update' , function(){
     var id = $('#sickbeard #show .manage').attr('tvdbid');
-    $.get(WEBROOT + '/sickbeard/update_show/'+id)
+    $.get(WEBROOT + '/xhr/sickbeard/update_show/'+id)
     .success(function(data){
       popup_message(data);
     })
@@ -1000,7 +1000,7 @@ $(document).ready(function() {
 
   // Shutoff function
   $(document).on('click', '#sickbeard div.powerholder .power', function(){
-    $.get(WEBROOT + '/sickbeard/shutdown')
+    $.get(WEBROOT + '/xhr/sickbeard/shutdown')
     .success(function(data){
       popup_message(data);
     })
@@ -1011,7 +1011,7 @@ $(document).ready(function() {
 
   // Restart Function
   $(document).on('click', '#sickbeard div.powerholder .restart', function(){
-    $.get(WEBROOT + '/sickbeard/restart')
+    $.get(WEBROOT + '/xhr/sickbeard/restart')
     .success(function(data){
       popup_message(data);
     })
@@ -1022,7 +1022,7 @@ $(document).ready(function() {
 
   // Log function
   $(document).on('click', '#sickbeard div.powerholder .log', function(){
-    $.get(WEBROOT + '/sickbeard/log/error', function(data){
+    $.get(WEBROOT + '/xhr/sickbeard/log/error', function(data){
       $('#sickbeard').replaceWith(data);
     });
   });
@@ -1030,14 +1030,14 @@ $(document).ready(function() {
   // Log info level change
   $(document).on('change', '#sickbeard #log .level', function(){
     var level = $('#sickbeard #log .level').attr('value');
-    $.get(WEBROOT + '/sickbeard/log/'+level, function(data){
+    $.get(WEBROOT + '/xhr/sickbeard/log/'+level, function(data){
       $('#sickbeard').replaceWith(data);
     });
   });
 
   // Load search template
   $(document).on('click', '#sickbeard div.powerholder .add', function(){
-    $.get(WEBROOT + '/sickbeard/search/')
+    $.get(WEBROOT + '/xhr/sickbeard/search/')
     .success(function(data){
       $('#sickbeard').replaceWith(data);
     })
@@ -1056,7 +1056,7 @@ $(document).ready(function() {
       if(name !== ''){
         params = 'name='+name;
       }
-      $.get(WEBROOT + '/sickbeard/search/?'+params)
+      $.get(WEBROOT + '/xhr/sickbeard/search/?'+params)
       .success(function(data){
         $('#sickbeard').replaceWith(data);
       })
@@ -1072,7 +1072,7 @@ $(document).ready(function() {
     var lang = $('#sb_search #lang').find(':selected').val();
     var initial = $('#sb_search #quality').find(':selected').val();
     var params = 'lang='+lang+'&status='+status+'&initial='+initial;
-    $.get(WEBROOT + '/sickbeard/add_show/'+$(this).attr('tvdbid')+'/?'+params)
+    $.get(WEBROOT + '/xhr/sickbeard/add_show/'+$(this).attr('tvdbid')+'/?'+params)
     .success(function(data){
       popup_message(data);
     })
@@ -1087,7 +1087,7 @@ $(document).ready(function() {
     var ep = $(this).attr('episode');
     var season = $(this).attr('season');
     var id = $(this).attr('id');
-    $.get(WEBROOT + '/sickbeard/search_ep/'+id+'/'+season+'/'+ep)
+    $.get(WEBROOT + '/xhr/sickbeard/search_ep/'+id+'/'+season+'/'+ep)
     .success(function(data){
       console.log(data.result);
       if(data.result === "failure"){
@@ -1107,7 +1107,7 @@ $(document).ready(function() {
     var season = $(this).attr('season');
     var id = $(this).attr('id');
     var status = this.value;
-    $.get(WEBROOT + '/sickbeard/set_ep_status/'+id+'/'+season+'/'+ep+'/'+status)
+    $.get(WEBROOT + '/xhr/sickbeard/set_ep_status/'+id+'/'+season+'/'+ep+'/'+status)
     .success(function(data){
       if (data.status !== 'success') {
         popup_message('An error ocurred: '+data);
@@ -2173,7 +2173,7 @@ $(document).ready(function() {
   });
 
   $(document).on('click', '#traktplus .add_sickbeard', function() {
-    $.get(WEBROOT + '/sickbeard/search/?tvdbid=' + $(this).data('tvdb_id'), function(data){
+    $.get(WEBROOT + '/xhr/sickbeard/search/?tvdbid=' + $(this).data('tvdb_id'), function(data){
       $('#sickbeard').replaceWith(data);
     });
   });
@@ -3083,10 +3083,10 @@ $(document).ready(function() {
       } else  if (data.status == 'Command Required') {
         $('#add_edit_script_dialog label[for=id_script_command]').html('Command (required) <span class="invalid">(invalid)</span>');
       } else if (data.status == 'Label Required'){
-      	$('#add_edit_script_dialog label[for=id_script_label]').html('Label (required) <span class="invalid">(invalid)</span>');
+        $('#add_edit_script_dialog label[for=id_script_label]').html('Label (required) <span class="invalid">(invalid)</span>');
       } else {
         $('#add_edit_script_dialog label[for=id_script_command]').html('Command (required) <span class="invalid">(invalid)</span>');
-      	$('#add_edit_script_dialog label[for=id_script_label]').html('Label (required) <span class="invalid">(invalid)</span>');
+        $('#add_edit_script_dialog label[for=id_script_label]').html('Label (required) <span class="invalid">(invalid)</span>');
       }
     });
   });
@@ -3103,7 +3103,7 @@ $(document).ready(function() {
 
   $(document).on('click', '#script_launcher .script', function() {
     $.get(WEBROOT + '/xhr/script_launcher/start_script/' + $(this).data('id'), function(data) {
-    	$('#script_launcher').replaceWith(data);
+        $('#script_launcher').replaceWith(data);
     });
   });
 

--- a/static/js/mobile/mobile.js
+++ b/static/js/mobile/mobile.js
@@ -145,7 +145,7 @@ $(document).ready(function () {
 
     $(document).on('click', '#sickbeard #results li', function() {
         $.mobile.showPageLoadingMsg();
-        $.get(WEBROOT + '/sickbeard/add_show/' + $(this).data('id'), function(data) {
+        $.get(WEBROOT + '/xhr/sickbeard/add_show/' + $(this).data('id'), function(data) {
             popup_message(data);
             $.mobile.hidePageLoadingMsg();
         });
@@ -156,7 +156,7 @@ $(document).ready(function () {
     $(document).on('click', '#sickbeard.show #control a', function() {
         $.mobile.showPageLoadingMsg();
         action = $(this).attr('id');
-        $.get(WEBROOT + '/sickbeard/' + action + '_show/' + $(this).data('id'), function(data) {
+        $.get(WEBROOT + '/xhr/sickbeard/' + action + '_show/' + $(this).data('id'), function(data) {
             popup_message(data);
             $.mobile.hidePageLoadingMsg();
         });


### PR DESCRIPTION
On my home server I have the following configuration of services available from the same domain:

/ - reverse proxy to maraschino
/sickbeard - reverse proxy to sickbeard
/couchpotato - reverse proxy to couchpotato
/transmission - reverse proxy to transmission

Generally this works, but I noticed that Maraschino used "/sickbeard" as a path prefix, which meant that proxied API calls from Maraschino's UI -> Maraschino -> Sickbeard were being routed directly to sickbeard and failing. This change modifies the maraschino routes to use "/xhr/sickbeard" instead, which mirrors the couchpotato module behavior and reduces the chance of path conflicts.
