### PR TITLE
Fix broken "Recently Added" XBMC images under Gotham

### DIFF
--- a/maraschino/tools.py
+++ b/maraschino/tools.py
@@ -225,7 +225,7 @@ def xbmc_proxy(version, label):
     if version == 'eden':
         url = '%s/vfs/special://%s' % (xbmc_url, url)
     elif version == 'frodo':
-        url = '%s/image/image://%s' % (xbmc_url, urllib.quote(url.encode('utf-8'), ''))
+        url = '%s/image/image://%s' % (xbmc_url, url.encode('utf-8'))
 
     img = StringIO.StringIO(urllib.urlopen(url).read())
     return send_file(img, mimetype='image/jpeg')


### PR DESCRIPTION
After updating to Gotham, all the "Recently Added" thumbnails broke. All the images were there, but invalid. Upon further inspection, these were HTML files with "Not Found" in them, returned from XBMC:

`<html><head><title>File not found</title></head><body>File not found</body></html>`

I had a difficult time figuring out how to get XBMC to log requests, so I don't know what exactly was annoying it. When I tested hitting XBMC with `curl`, I didn't do what "urllib.quote()" does, and it worked (it looks like the path is already url encoded in the request, so maybe it was double-encoded?). I made the equivalent change in `tools.py` and it fixed the issue.

That being said, this could have broken for another reason and this just fixes it by mistake :)

Regardless, I am assuming it will break older versions, in which case, this fix isn't appropriate, but it's beyond my knowledge of maraschino to create a new "version" (ie "eden", "frodo", etc) and use it as an additional condition here. 

This is just a heads up to point someone else in the right direction if they're having the same issue
