### PR TITLE
Update initd

### DIFF
--- a/initd
+++ b/initd
@@ -80,7 +80,7 @@ load_settings() {
 
         [ -n "$WEBROOT" ] && DAEMON_OPTS="$DAEMON_OPTS --webroot=$WEBROOT"
 
-        [ $KIOSK -eq 1 ] && DAEMON_OPTS="$DAEMON_OPTS --kiosk"
+        [ -n "$KIOSK" ] && [ $KIOSK -eq 1 ] && DAEMON_OPTS="$DAEMON_OPTS --kiosk"
 
         [ -n "$PID_FILE" ] && PID_FILE=$PID_FILE
         [ -n "$PID_FILE" ] || PID_FILE=/var/run/maraschino/maraschino.pid


### PR DESCRIPTION
Stop "/etc/init.d/maraschino: 83: [: -eq: unexpected operator" because $KIOSK isnt set by default
