### PR TITLE
Search module bug fix

### DIFF
--- a/modules/search.py
+++ b/modules/search.py
@@ -44,14 +44,20 @@ def get_newznab_sites():
 @app.route('/xhr/search/')
 @app.route('/xhr/search/<site>')
 @requires_auth
-def xhr_search(site=1):
+def xhr_search(site=0):
     if get_setting_value('search') == '0':
         logger.log('SEARCH :: Search fature not enabled, please enable it on the top right corner menu', 'INFO')
         return ''
 
-    site = int(site)
-    newznab = NewznabSite.query.filter(NewznabSite.id == site).first()
-    categories = cat_newznab(newznab.url)
+    try:
+        site = int(site)
+        if site == 0:
+            newznab = NewznabSite.query.order_by(NewznabSite.id).first()
+        else:
+            newznab = NewznabSite.query.filter(NewznabSite.id == site).first()
+        categories = cat_newznab(newznab.url)
+    except Exception, e:
+        logger.log('SEARCH :: Exception %s' % e, 'ERROR')
 
     return render_template('search.html',
         site=site,


### PR DESCRIPTION
Fix for bug where removing the first website from the search module would cause it to stop working.
Now it defaults to the "oldest" (smallest id number).

Reason: 
It used to be that the search module by default tried to find the website with id = 1 however if a user deletes their first website the db would not shift the other ones back to 1 causing it to crash. Now it defaults to id closest to 1 (smallest out of all of them). 

I also added a small log entry when failing to grab the newznab entry from the db.
